### PR TITLE
fix floodlight on styled lightmaps

### DIFF
--- a/code/compiler/includes/q3map2.h
+++ b/code/compiler/includes/q3map2.h
@@ -2275,12 +2275,14 @@ Q_EXTERN float dirtGain Q_ASSIGN( 1.0f );
 
 /* 27: floodlighting */
 Q_EXTERN qboolean debugnormals Q_ASSIGN( qfalse );
-Q_EXTERN qboolean floodlighty Q_ASSIGN( qfalse );
+Q_EXTERN qboolean g_floodlight Q_ASSIGN( qfalse );
 Q_EXTERN qboolean floodlight_lowquality Q_ASSIGN( qfalse );
 Q_EXTERN vec3_t floodlightRGB;
 Q_EXTERN float floodlightIntensity Q_ASSIGN( 512.0f );
 Q_EXTERN float floodlightDistance Q_ASSIGN( 1024.0f );
 Q_EXTERN float floodlightDirectionScale Q_ASSIGN( 1.0f );
+Q_EXTERN qboolean g_noFloodLight Q_ASSIGN(qfalse);
+Q_EXTERN qboolean g_noFloodStyles Q_ASSIGN(qfalse);
 
 Q_EXTERN qboolean dump Q_ASSIGN( qfalse );
 Q_EXTERN qboolean debug Q_ASSIGN( qfalse );

--- a/code/compiler/light.cpp
+++ b/code/compiler/light.cpp
@@ -1636,7 +1636,7 @@ void TraceGrid( int num ){
 
 	/////// Floodlighting for point //////////////////
 	//do our floodlight ambient occlusion loop, and add a single contribution based on the brightest dir
-	if ( floodlighty ) {
+	if ( g_floodlight ) {
 		int k;
 		float addSize, f;
 		vec3_t dir = { 0, 0, 1 };
@@ -2044,7 +2044,7 @@ void LightWorld( const char *BSPFilePath, qboolean fastAllocate ){
 		/* flag bouncing */
 		bouncing = qtrue;
 		VectorClear( ambientColor );
-		floodlighty = qfalse;
+		g_floodlight = qfalse;
 
 		/* generate diffuse lights */
 		RadFreeLights();
@@ -2810,8 +2810,16 @@ int LightMain( int argc, char **argv ){
 			Sys_Printf( "Enabling Challenge Pro Mode Asstacular Vertex Lighting Mode (tm)\n" );
 		}
 		else if ( !strcmp( argv[ i ], "-floodlight" ) ) {
-			floodlighty = qtrue;
+			g_floodlight = qtrue;
 			Sys_Printf( "FloodLighting enabled\n" );
+		}
+		else if (!strcmp(argv[i], "-nofloodlight")) {
+			g_noFloodLight = qtrue;
+			Sys_Printf("FloodLighting disabled\n");
+		}
+		else if (!strcmp(argv[i], "-nofloodstyles")) {
+			g_noFloodStyles = qtrue;
+			Sys_Printf("Floodlights won't affect styled lightmaps\n");
 		}
 		else if ( !strcmp( argv[ i ], "-debugnormals" ) ) {
 			debugnormals = qtrue;


### PR DESCRIPTION
Floodlight was applying brightness over the completely black areas
of the styled lightmaps, which it should not, otherwise flickering
of unwanted areas would appear.

* added `-nofloodlight` flag to force floodlighting to be disabled
* added `-nofloodstyles` flag to disable floodlighting on the styled lightmaps

refs #4