### PR TITLE
added support to set bounce color if no lightimage

### DIFF
--- a/code/compiler/compiler.cpp
+++ b/code/compiler/compiler.cpp
@@ -186,8 +186,10 @@ int compilerMain(int argc, char **argv) {
 	/* we print out two versions, q3map's main version (since it evolves a bit out of GtkRadiant)
 	   and we put the GtkRadiant version to make it easy to track with what version of Radiant it was built with */
 
-	Sys_Printf( "Q3Map         - v1.0r (c) 1999 Id Software Inc.\n" );
-	Sys_Printf( "Q3Map (ydnar) - v" Q3MAP_VERSION  " " __DATE__ " " __TIME__ "\n");
+	Sys_Printf( "Q3Map              - v1.0r (c) 1999 Id Software Inc.\n" );
+	Sys_Printf( "Q3Map (ydnar)      - v2.5.17\n" );
+	Sys_Printf( "Q3Map (NetRadiant) - v2.5.17n\n" );
+	Sys_Printf( "Q3Map (ryven)      - v" Q3MAP_VERSION  " " __DATE__ " " __TIME__ "\n" );
 	Sys_Printf( "%s\n", Q3MAP_MOTD );
 
 	/* ydnar: new path initialization */

--- a/code/compiler/includes/q3map2.h
+++ b/code/compiler/includes/q3map2.h
@@ -797,6 +797,8 @@ typedef struct shaderInfo_s
 	char                *shaderText;                    /* ydnar */
 	qb_t custom;
 	qb_t finished;
+
+	bool hasOwnLightImage;
 }
 shaderInfo_t;
 
@@ -2397,6 +2399,8 @@ Q_EXTERN int lightsClusterCulled;
 Q_EXTERN float diffuseSubdivide Q_ASSIGN( 256.0f );
 Q_EXTERN float minDiffuseSubdivide Q_ASSIGN( 64.0f );
 Q_EXTERN int numDiffuseSurfaces Q_ASSIGN( 0 );
+Q_EXTERN vec3_t g_customBounceColor;
+Q_EXTERN bool g_hasCustomBounceColorSet Q_ASSIGN(false);
 
 /* ydnar: list of surface information necessary for lightmap calculation */
 Q_EXTERN surfaceInfo_t      *surfaceInfos Q_ASSIGN( NULL );

--- a/code/compiler/light.cpp
+++ b/code/compiler/light.cpp
@@ -2996,6 +2996,20 @@ int LightMain( int argc, char **argv ){
 	/* inject command line parameters */
 	InjectCommandLine( argv, 0, argc - 1 );
 
+	if (GetVectorForKey(&entities[0], "_bounceColor", g_customBounceColor))
+	{
+		g_hasCustomBounceColorSet = true;
+
+		if (colorsRGB) {
+			g_customBounceColor[0] = Image_LinearFloatFromsRGBFloat(g_customBounceColor[0]);
+			g_customBounceColor[1] = Image_LinearFloatFromsRGBFloat(g_customBounceColor[1]);
+			g_customBounceColor[2] = Image_LinearFloatFromsRGBFloat(g_customBounceColor[2]);
+		}
+
+		ColorNormalize(g_customBounceColor, g_customBounceColor);
+		VectorScale(g_customBounceColor, 255.f, g_customBounceColor);
+	}
+
 	/* load map file */
 	value = ValueForKey( &entities[ 0 ], "_keepLights" );
 	if ( value[ 0 ] != '1' ) {

--- a/code/compiler/light_bounce.cpp
+++ b/code/compiler/light_bounce.cpp
@@ -369,11 +369,20 @@ static void RadSample( int lightmapNum, bspDrawSurface_t *ds, rawLightmap_t *lm,
 						/* inc samples */
 						samples++;
 
-						/* multiply by texture color */
-						if ( !RadSampleImage( si->lightImage->pixels, si->lightImage->width, si->lightImage->height, st, textureColor ) ) {
-							VectorCopy( si->averageColor, textureColor );
-							textureColor[ 3 ] = 255;
+						if (!si->hasOwnLightImage && g_hasCustomBounceColorSet)
+						{
+							VectorCopy(g_customBounceColor, textureColor);
+							textureColor[3] = 255.f;
+						} 
+						else
+						{
+							/* multiply by texture color */
+							if (!RadSampleImage(si->lightImage->pixels, si->lightImage->width, si->lightImage->height, st, textureColor)) {
+								VectorCopy(si->averageColor, textureColor);
+								textureColor[3] = 255.f;
+							}
 						}
+						
 						for ( i = 0; i < 3; i++ )
 							color[ i ] = ( textureColor[ i ] / 255 ) * ( radLuxel[ i ] / 255 );
 

--- a/code/compiler/shaders.cpp
+++ b/code/compiler/shaders.cpp
@@ -789,8 +789,12 @@ static void LoadShaderImages( shaderInfo_t *si ){
 	}
 
 	/* if no light image, use shader image */
-	if ( si->lightImage == NULL ) {
-		si->lightImage = ImageLoad( si->shaderImage->name );
+	if ( si->lightImage ) {
+		si->hasOwnLightImage = true;
+	} 
+	else
+	{
+		si->lightImage = ImageLoad(si->shaderImage->name);
 	}
 
 	/* create default and average colors */


### PR DESCRIPTION
Added `_bounceColor` worldspawn key to set bounce color.
In case `q3map_lightImage` is not set for shader, surface will be lit using bounce color value.

`_bounceColor R G B`

closes #6 