### PR TITLE
fix old bsp won't decompile

### DIFF
--- a/code/compiler/bspfile_ibsp.cpp
+++ b/code/compiler/bspfile_ibsp.cpp
@@ -457,7 +457,7 @@ void LoadIBSPFile( const char *filename ){
 
 
 	/* load the file header */
-	LoadFile( filename, (void**) &header );
+	int bspLength = LoadFile( filename, (void**) &header );
 
 	/* swap the header (except the first 4 bytes) */
 	SwapBlock( (int*) ( (byte*) header + sizeof( int ) ), sizeof( *header ) - sizeof( int ) );
@@ -507,11 +507,15 @@ void LoadIBSPFile( const char *filename ){
 
 	CopyLightGridLumps( header );
 
+	bspLump_t *preLastLump = &header->lumps[LUMP_DRAWINDEXES];
+	int currentSize = preLastLump->offset + preLastLump->length;
+
 	/* advertisements */
-	if ( header->version == 47 ) { // quake live's bsp version
+	if ( currentSize < bspLength && header->version == 47 ) { // quake live's bsp version
 		numBSPAds = CopyLump( (bspHeader_t*) header, LUMP_ADVERTISEMENTS, bspAds, sizeof( bspAdvertisement_t ) );
 	}
-	else{
+	else 
+	{
 		numBSPAds = 0;
 	}
 


### PR DESCRIPTION
Added Quake Live support in `q3map2 2.5.17` introduced a new bsp lump, that contains advertisements data, but didn't bother to increase protocol version, or rather it is increased relatively to quake 3, but still has same protocol number as rtcw and et. Whilst trying to decompile older bsp files, that have been compiled with older map compiler, will lead to a "funny lump size" error because advertisement lump being processed despite the fact there is no more data left. This doesn't happen on a maps compiled with newer compiler versions due to the fact it still writes an empty lump information to the end of bsp, so the compiler always knows there is nothing left to fetch.

This commit adds a bsp file size check to make sure that after prelast lump, there is still a data left to process, otherwise it doen't bother to continue.