### PR TITLE
Add new flag to automatically set map coords

### DIFF
--- a/code/compiler/bsp.cpp
+++ b/code/compiler/bsp.cpp
@@ -1016,6 +1016,17 @@ int BSPMain( int argc, char **argv ){
 		else if ( !strcmp( argv[ i ], "-bsp" ) ) {
 			Sys_Printf( "-bsp argument unnecessary\n" );
 		}
+		else if (!strcmp(argv[i], "-automapcoords"))
+		{
+			g_autoMapCoords = true;
+			Sys_Printf("Map coords will be set automatically\n");
+		}
+		else if (!strcmp(argv[i], "-automapcoordspad"))
+		{
+			g_autoMapCoordsPad = atof(argv[i + 1]);
+			i++;
+			Sys_Printf("Map coords padding is set to %.3f%%\n", g_autoMapCoordsPad * 100.f);
+		}
 		else{
 			Sys_FPrintf( SYS_WRN, "WARNING: Unknown option \"%s\"\n", argv[ i ] );
 		}

--- a/code/compiler/includes/q3map2.h
+++ b/code/compiler/includes/q3map2.h
@@ -2462,7 +2462,8 @@ Q_EXTERN vec3_t gridSize
 	= { 64, 64, 128 };
 #endif
 
-
+Q_EXTERN bool g_autoMapCoords Q_ASSIGN(false);
+Q_EXTERN float g_autoMapCoordsPad Q_ASSIGN(0.0f);
 
 /* -------------------------------------------------------------------------------
 


### PR DESCRIPTION
* `-automapcoords` injects automatically calculated map coordinates in a compiled map as `mapcoordsmins`/`mapcoordsmaxs` keys.
* `-automapcoordspad` sets padding around automatically calculated map coords in a percentage form, expects normalized values. The final padding is calculated relatively to the map size.

closes #32