### PR TITLE
Remove deprecate light switches

### DIFF
--- a/code/compiler/compiler.cpp
+++ b/code/compiler/compiler.cpp
@@ -230,13 +230,6 @@ int compilerMain(int argc, char **argv) {
 		r = LightMain( argc - 1, argv + 1 );
 	}
 
-	/* vlight */
-	else if ( !strcmp( argv[ 1 ], "-vlight" ) ) {
-		Sys_FPrintf( SYS_WRN, "WARNING: VLight is no longer supported, defaulting to -light -fast instead\n\n" );
-		argv[ 1 ] = "-fast";    /* eek a hack */
-		r = LightMain( argc, argv );
-	}
-
 	/* QBall: export entities */
 	else if ( !strcmp( argv[ 1 ], "-exportents" ) ) {
 		r = ExportEntitiesMain( argc - 1, argv + 1 );

--- a/code/compiler/includes/q3map2.h
+++ b/code/compiler/includes/q3map2.h
@@ -248,9 +248,6 @@
 #define DEFAULT_LIGHTMAP_SAMPLE_OFFSET  1.0f
 #define DEFAULT_SUBDIVIDE_THRESHOLD     1.0f
 
-#define EXTRA_SCALE             2   /* -extrawide = -super 2 */
-#define EXTRAWIDE_SCALE         2   /* -extrawide = -super 2 -filter */
-
 #define CLUSTER_UNMAPPED        -1
 #define CLUSTER_OCCLUDED        -2
 #define CLUSTER_FLOODED         -3

--- a/code/compiler/light.cpp
+++ b/code/compiler/light.cpp
@@ -2617,11 +2617,6 @@ int LightMain( int argc, char **argv ){
 			}
 		}
 
-		else if ( !strcmp( argv[ i ], "-smooth" ) ) {
-			lightSamples = EXTRA_SCALE;
-			Sys_Printf( "The -smooth argument is deprecated, use \"-samples 2\" instead\n" );
-		}
-
 		else if ( !strcmp( argv[ i ], "-nofastpoint" ) ) {
 			fastpoint = qfalse;
 			Sys_Printf( "Automatic fast mode for point lights disabled\n" );
@@ -2721,15 +2716,6 @@ int LightMain( int argc, char **argv ){
 		else if ( !strcmp( argv[ i ], "-patchshadows" ) ) {
 			patchShadows = qtrue;
 			Sys_Printf( "Patch shadow casting enabled\n" );
-		}
-		else if ( !strcmp( argv[ i ], "-extra" ) ) {
-			superSample = EXTRA_SCALE;      /* ydnar */
-			Sys_Printf( "The -extra argument is deprecated, use \"-super 2\" instead\n" );
-		}
-		else if ( !strcmp( argv[ i ], "-extrawide" ) ) {
-			superSample = EXTRAWIDE_SCALE;  /* ydnar */
-			filter = qtrue;                 /* ydnar */
-			Sys_Printf( "The -extrawide argument is deprecated, use \"-filter [-super 2]\" instead\n" );
 		}
 		else if ( !strcmp( argv[ i ], "-samplesize" ) ) {
 			sampleSize = atoi( argv[ i + 1 ] );


### PR DESCRIPTION
Removes `-smooth (-samples 2)`, `-extra (-super 2)` and `-extrawide (-super 2 -filter)`.