### PR TITLE
Feature nolightmap flag

### DIFF
--- a/code/compiler/help.cpp
+++ b/code/compiler/help.cpp
@@ -221,6 +221,7 @@ void HelpLight()
 		{"-nofloodstyles", "Disable floodlighting on styled lightmaps"},
 		{"-nodeluxe, -nodeluxemap", "Disable deluxemapping"},
 		{"-nogrid", "Disable grid light calculation (makes all entities fullbright)"},
+		{"-nolightmap", "Disables lightmap generation for all surfaces, making them vertex lit"},
 		{"-nolightmapsearch", "Do not optimize lightmap packing for GPU memory usage (as doing so costs fps)"},
 		{"-nosRGB", "Disable sRGB color for lightmaps, textures and light colors"},
 		{"-nosRGBcolor", "Disable sRGB color for light colors"},

--- a/code/compiler/includes/q3map2.h
+++ b/code/compiler/includes/q3map2.h
@@ -2461,6 +2461,7 @@ Q_EXTERN vec3_t gridSize
 Q_EXTERN bool g_autoMapCoords Q_ASSIGN(false);
 Q_EXTERN float g_autoMapCoordsPad Q_ASSIGN(0.0f);
 Q_EXTERN bool g_fastAllocate Q_ASSIGN(true);
+Q_EXTERN bool g_bakeLightmap Q_ASSIGN(true);
 
 /* -------------------------------------------------------------------------------
 

--- a/code/compiler/light.cpp
+++ b/code/compiler/light.cpp
@@ -2873,6 +2873,11 @@ int LightMain( int argc, char **argv ){
 			i++;
 			Sys_Printf("Use %s as surface file\n", surfaceFilePath);
 		}
+		else if (!_stricmp(argv[i], "-nolightmap"))
+		{
+			g_bakeLightmap = false;
+			Sys_Printf("Lightmap baking is disabled, map is lit by vertex lighting\n");
+		}
 		/* unhandled args */
 		else
 		{

--- a/code/compiler/lightmaps_ydnar.cpp
+++ b/code/compiler/lightmaps_ydnar.cpp
@@ -1095,8 +1095,11 @@ void SetupSurfaceLightmaps( void ){
 			}
 			else
 			{
-				numSurfsLightmapped++;
-				info->hasLightmap = qtrue;
+				if (g_bakeLightmap)
+				{
+					numSurfsLightmapped++;
+					info->hasLightmap = qtrue;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Added `-nolightmap`  switch to disable lightmap generation for surface, forcing map vertex lit

closes #48 #24 