### PR TITLE
[WIP] Add converter switches to extract only models

### DIFF
--- a/src/convert_ase.cpp
+++ b/src/convert_ase.cpp
@@ -36,21 +36,6 @@
 /* dependencies */
 #include "q3map2.h"
 
-static bool isValidSurfaceType(bspSurfaceType_t type) {
-	/* ignore patches for now */
-	if (!g_onlyModels && type == MST_PLANAR || type == MST_TRIANGLE_SOUP) {
-		return true;
-	}
-	return false;
-}
-
-static bool isValidShaderName(const char *shaderName) {
-	if (g_onlyShader[0] != 0) {
-		return Q_stricmp(g_onlyShader, shaderName) == 0;
-	}
-	return true;
-}
-
 /*
    ConvertSurface()
    converts a bsp drawsurface to an ase chunk
@@ -64,11 +49,11 @@ static void ConvertSurface( FILE *f, bspModel_t *model, int modelNum, bspDrawSur
 	char name[ 1024 ];
 
 
-	if (!isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
+	if (!BSPConverter::isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
 		return;
 	}
 
-	if (!isValidShaderName(bspShaders[ds->shaderNum].shader)) {
+	if (!BSPConverter::isValidShaderName(bspShaders[ds->shaderNum].shader)) {
 		return;
 	}
 
@@ -265,6 +250,9 @@ static void ConvertShader( FILE *f, bspShader_t *shader, int shaderNum ){
 	shaderInfo_t    *si;
 	char            *c, filename[ 1024 ];
 
+	if (!BSPConverter::isValidShaderName(shader->shader)) {
+		return;
+	}
 
 	/* get shader */
 	si = ShaderInfoForShader( shader->shader );

--- a/src/convert_ase.cpp
+++ b/src/convert_ase.cpp
@@ -36,7 +36,20 @@
 /* dependencies */
 #include "q3map2.h"
 
+static bool isValidSurfaceType(bspSurfaceType_t type) {
+	/* ignore patches for now */
+	if (!g_onlyModels && type == MST_PLANAR || type == MST_TRIANGLE_SOUP) {
+		return true;
+	}
+	return false;
+}
 
+static bool isValidShaderName(const char *shaderName) {
+	if (g_onlyShader[0] != 0) {
+		return Q_stricmp(g_onlyShader, shaderName) == 0;
+	}
+	return true;
+}
 
 /*
    ConvertSurface()
@@ -51,8 +64,11 @@ static void ConvertSurface( FILE *f, bspModel_t *model, int modelNum, bspDrawSur
 	char name[ 1024 ];
 
 
-	/* ignore patches for now */
-	if ( ds->surfaceType != MST_PLANAR && ds->surfaceType != MST_TRIANGLE_SOUP ) {
+	if (!isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
+		return;
+	}
+
+	if (!isValidShaderName(bspShaders[ds->shaderNum].shader)) {
 		return;
 	}
 

--- a/src/convert_bsp.cpp
+++ b/src/convert_bsp.cpp
@@ -31,7 +31,27 @@
 /* dependencies */
 #include "q3map2.h"
 
+namespace BSPConverter {
+	bool isValidSurfaceType(bspSurfaceType_t type) {
+		/* ignore patches for now */
+		if (!g_onlyModels && type == MST_PLANAR || type == MST_TRIANGLE_SOUP) {
+			return true;
+		}
+		return false;
+	}
 
+	bool isValidShaderName(const char *shaderName) {
+		if (g_onlyShaders[0][0] != 0) {
+			for (int i = 0; i < 10 && g_onlyShaders[i][0]; i++) {
+				if (Q_stricmp(g_onlyShaders[i], shaderName) == 0) {
+					return true;
+				}
+			}
+			return false;
+		}
+		return true;
+	}
+}
 
 /*
    PseudoCompileBSP()
@@ -228,13 +248,14 @@ int ConvertBSPMain( int argc, char **argv ){
 			g_onlyModels = true;
 			Sys_Printf("Only models are going to be extracted\n");
 		}
-		else if (!Q_stricmp(argv[i], "-onlyshader")) {
-			if (i + 1 == argc || Q_strncasecmp(argv[i + 1], "-", 1) == 0) {
-				Sys_Printf("Warning: -onlyshader switch expects shader name to be set, but found none\n");
-			}
-			else {
-				strncpy(g_onlyShader, argv[i + 1], 64);
+		else if (!Q_stricmp(argv[i], "-onlyshaders")) {
+			int k = i, finalIndex = argc - 1;
+			while (i + 1 < finalIndex && Q_strncasecmp(argv[i + 1], "-", 1)) {
+				strncpy(g_onlyShaders[i - k], argv[i + 1], 64);
 				i++;
+			}
+			if (g_onlyShaders[0][0] == 0) {
+				Sys_Printf("Warning: -onlyshaders switch expects shader names to be set, but none was found\n");
 			}
 		}
 		else if (!Q_stricmp(argv[i], "-outfile"))

--- a/src/convert_bsp.cpp
+++ b/src/convert_bsp.cpp
@@ -224,6 +224,19 @@ int ConvertBSPMain( int argc, char **argv ){
 			meta = qtrue;
 			patchMeta = qtrue;
 		}
+		else if (!Q_stricmp(argv[i], "-onlymodels")) {
+			g_onlyModels = true;
+			Sys_Printf("Only models are going to be extracted\n");
+		}
+		else if (!Q_stricmp(argv[i], "-onlyshader")) {
+			if (i + 1 == argc || Q_strncasecmp(argv[i + 1], "-", 1) == 0) {
+				Sys_Printf("Warning: -onlyshader switch expects shader name to be set, but found none\n");
+			}
+			else {
+				strncpy(g_onlyShader, argv[i + 1], 64);
+				i++;
+			}
+		}
 		else if (!Q_stricmp(argv[i], "-outfile"))
 		{
 			if (i + 1 < argc - 1)

--- a/src/convert_obj.cpp
+++ b/src/convert_obj.cpp
@@ -37,6 +37,20 @@
 #include "q3map2.h"
 
 
+static bool isValidSurfaceType(bspSurfaceType_t type) {
+	/* ignore patches for now */
+	if ( !g_onlyModels && type == MST_PLANAR || type == MST_TRIANGLE_SOUP) {
+		return true;
+	}
+	return false;
+}
+
+static bool isValidShaderName(const char *shaderName) {
+	if (g_onlyShader[0] != 0) {
+		return Q_stricmp(g_onlyShader, shaderName) == 0;
+	}
+	return true;
+}
 
 /*
    ConvertSurface()
@@ -53,8 +67,11 @@ static void ConvertSurfaceToOBJ( FILE *f, bspModel_t *model, int modelNum, bspDr
 	int i, v, a, b, c;
 	bspDrawVert_t   *dv;
 
-	/* ignore patches for now */
-	if ( ds->surfaceType != MST_PLANAR && ds->surfaceType != MST_TRIANGLE_SOUP ) {
+	if (!isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
+		return;
+	}
+
+	if (!isValidShaderName(bspShaders[ds->shaderNum].shader)) {
 		return;
 	}
 

--- a/src/convert_obj.cpp
+++ b/src/convert_obj.cpp
@@ -36,22 +36,6 @@
 /* dependencies */
 #include "q3map2.h"
 
-
-static bool isValidSurfaceType(bspSurfaceType_t type) {
-	/* ignore patches for now */
-	if ( !g_onlyModels && type == MST_PLANAR || type == MST_TRIANGLE_SOUP) {
-		return true;
-	}
-	return false;
-}
-
-static bool isValidShaderName(const char *shaderName) {
-	if (g_onlyShader[0] != 0) {
-		return Q_stricmp(g_onlyShader, shaderName) == 0;
-	}
-	return true;
-}
-
 /*
    ConvertSurface()
    converts a bsp drawsurface to an obj chunk
@@ -67,11 +51,11 @@ static void ConvertSurfaceToOBJ( FILE *f, bspModel_t *model, int modelNum, bspDr
 	int i, v, a, b, c;
 	bspDrawVert_t   *dv;
 
-	if (!isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
+	if (!BSPConverter::isValidSurfaceType(static_cast<bspSurfaceType_t>(ds->surfaceType))) {
 		return;
 	}
 
-	if (!isValidShaderName(bspShaders[ds->shaderNum].shader)) {
+	if (!BSPConverter::isValidShaderName(bspShaders[ds->shaderNum].shader)) {
 		return;
 	}
 
@@ -173,6 +157,9 @@ static void ConvertShaderToMTL( FILE *f, bspShader_t *shader, int shaderNum ){
 	shaderInfo_t    *si;
 	char filename[ 1024 ];
 
+	if (!BSPConverter::isValidShaderName(shader->shader)) {
+		return;
+	}
 
 	/* get shader */
 	si = ShaderInfoForShader( shader->shader );

--- a/src/q3map2.h
+++ b/src/q3map2.h
@@ -1906,6 +1906,10 @@ void                        WriteRBSPFile( const char *filename );
 
 void dumpLightsIntoPrefab(const char *prefix);
 
+namespace BSPConverter {
+	bool isValidSurfaceType(bspSurfaceType_t type);
+	bool isValidShaderName(const char *shaderName);
+}
 
 /* -------------------------------------------------------------------------------
 
@@ -2059,7 +2063,7 @@ Q_EXTERN int metaAdequateScore Q_ASSIGN( -1 );
 Q_EXTERN int metaGoodScore Q_ASSIGN( -1 );
 Q_EXTERN float metaMaxBBoxDistance Q_ASSIGN( -1 );
 Q_EXTERN bool g_onlyModels Q_ASSIGN(false);
-Q_EXTERN char g_onlyShader[64] Q_ASSIGN("");
+Q_EXTERN char g_onlyShaders[10][64] Q_ASSIGN({});
 
 #if Q3MAP2_EXPERIMENTAL_SNAP_NORMAL_FIX
 // Increasing the normalEpsilon to compensate for new logic in SnapNormal(), where

--- a/src/q3map2.h
+++ b/src/q3map2.h
@@ -2058,6 +2058,8 @@ Q_EXTERN qboolean lightmapFill Q_ASSIGN( qfalse );
 Q_EXTERN int metaAdequateScore Q_ASSIGN( -1 );
 Q_EXTERN int metaGoodScore Q_ASSIGN( -1 );
 Q_EXTERN float metaMaxBBoxDistance Q_ASSIGN( -1 );
+Q_EXTERN bool g_onlyModels Q_ASSIGN(false);
+Q_EXTERN char g_onlyShader[64] Q_ASSIGN("");
 
 #if Q3MAP2_EXPERIMENTAL_SNAP_NORMAL_FIX
 // Increasing the normalEpsilon to compensate for new logic in SnapNormal(), where


### PR DESCRIPTION
* added `-onlymodels` switch for `-convert` stage, that extracts only triangle surfaces from the bsp, which are baked `misc_models`.
* added `-onlyshaders` switch for `-convert` stage that filters out surfaces by shader names, supports up to 10 shader names.